### PR TITLE
bugfix for issue 28: should not check write permission of parent file location when drop an external table

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -917,7 +917,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           }
         }
         isExternal = isExternal(tbl);
-        if (tbl.getSd().getLocation() != null) {
+        if (tbl.getSd().getLocation() != null && !isExternal) {
           tblPath = new Path(tbl.getSd().getLocation());
           if (!wh.isWritable(tblPath.getParent())) {
             throw new MetaException("Table metadata not deleted since " +


### PR DESCRIPTION
see : https://github.com/dianping/cosmos-hive/issues/28
