### PR TITLE
hive bugfix HIVE-3149:Dynamically generated paritions deleted by Block l...

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/merge/BlockMergeTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/merge/BlockMergeTask.java
@@ -236,8 +236,12 @@ public class BlockMergeTask extends Task<MergeWork> implements Serializable,
           HadoopJobExecHelper.runningJobKillURIs.remove(rj.getJobID());
           jobID = rj.getID().toString();
         }
-        RCFileMergeMapper.jobClose(outputPath, success, job, console);
+        RCFileMergeMapper.jobClose(outputPath, success, job, console, work.getDynPartCtx());
       } catch (Exception e) {
+        console.printError("RCFile Merger Job Close Error", "\n"
+            + org.apache.hadoop.util.StringUtils.stringifyException(e));
+        success = false;
+        returnVal = -500;
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/merge/RCFileMergeMapper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/merge/RCFileMergeMapper.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.RCFile;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.DynamicPartitionCtx;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 import org.apache.hadoop.hive.shims.CombineHiveKey;
 import org.apache.hadoop.hive.shims.ShimLoader;
@@ -204,7 +205,7 @@ public class RCFileMergeMapper extends MapReduceBase implements
 
     if (!exception) {
       FileStatus fss = fs.getFileStatus(outPath);
-      System.out.println("renamed path " + outPath + " to " + finalPath
+      LOG.info("renamed path " + outPath + " to " + finalPath
           + " . File size is " + fss.getLen());
       if (!fs.rename(outPath, finalPath)) {
         throw new IOException("Unable to rename output to " + finalPath);
@@ -231,11 +232,11 @@ public class RCFileMergeMapper extends MapReduceBase implements
   }
 
   public static void jobClose(String outputPath, boolean success, JobConf job,
-      LogHelper console) throws HiveException, IOException {
+      LogHelper console, DynamicPartitionCtx dynPartCtx) throws HiveException, IOException {
     Path outpath = new Path(outputPath);
     FileSystem fs = outpath.getFileSystem(job);
     Path backupPath = backupOutputPath(fs, outpath, job);
-    Utilities.mvFileToFinalPath(outputPath, job, success, LOG, null, null);
+    Utilities.mvFileToFinalPath(outputPath, job, success, LOG, dynPartCtx, null);
     fs.delete(backupPath, true);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRFileSink1.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMRFileSink1.java
@@ -488,7 +488,7 @@ public class GenMRFileSink1 implements NodeProcessor {
       }
 
       MergeWork work = new MergeWork(inputDirs, finalName,
-          hasDynamicPartitions);
+          hasDynamicPartitions, fsInputDesc.getDynPartCtx());
       LinkedHashMap<String, ArrayList<String>> pathToAliases =
           new LinkedHashMap<String, ArrayList<String>>();
       pathToAliases.put(inputDir, (ArrayList<String>) inputDirs.clone());


### PR DESCRIPTION
Dynamically generated paritions deleted by Block level merge
